### PR TITLE
Allow localhost

### DIFF
--- a/src/EventListener/PageLayoutListener.php
+++ b/src/EventListener/PageLayoutListener.php
@@ -139,6 +139,10 @@ class PageLayoutListener {
 
         if (empty($licenseKey) || empty($licenseExpiryDate))
             return false;
+        
+        // Allow localhost
+        if (in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']))
+            return true;
 
         // in Frontend Y-m-d in Backend d.m.Y
         $licenseExpiryDate = date("Y-m-d", strtotime($licenseExpiryDate));


### PR DESCRIPTION
We are using the CookieOptInBundle on our website - [markenzoo.de](https://markenzoo.de).
The problem is that I am using a local installation during development, so the domain will be `localhost:8000`, which will trigger errors since the license key is not matched.

![Screenshot 2021-03-29 185504](https://user-images.githubusercontent.com/23213965/112873697-42944300-90c2-11eb-9744-93b544b9bbf4.png)

This PR fixes the problem, by allowing local remotes, i.e. `127.0.0.1` and `::1` during the `PageLayoutListener::checkLicense` method, using the `$_SERVER['REMOTE_ADDR']` field.

This check happens only if the license key and expiration date is not empty, so this should not affect the testing period.



