### PR TITLE
PHP8 Kompatiblitäts-Update

### DIFF
--- a/src/EventListener/PageLayoutListener.php
+++ b/src/EventListener/PageLayoutListener.php
@@ -240,18 +240,20 @@ class PageLayoutListener {
 
         $id = $page->__get('id');
         $repo = new Repository($database);
-        $strQueryContent = "SELECT html FROM tl_content as tc 
+        $strQueryContent = "SELECT html FROM tl_content as tc
         LEFT JOIN tl_article ta on tc.pid = ta.id
         LEFT JOIN tl_page tp on ta.pid = tp.id
         WHERE tp.id = ?";
         $htmlElements = $repo->findAllAssoc($strQueryContent,[], [$id]);
         $id = $layout->__get('id');
-        $strQueryModule = "SELECT html FROM tl_module as tm 
+        $strQueryModule = "SELECT html FROM tl_module as tm
                 LEFT JOIN tl_layout tlayout on tlayout.id = tm.pid
                 WHERE tlayout.id = ?"
         ;
         $htmlElementsLayout = $repo->findAllAssoc($strQueryModule,[], [$id]);
-        $htmlElements = array_merge($htmlElementsLayout,$htmlElements);
+        if($htmlElementsLayout !== NULL) {
+            $htmlElements = array_merge($htmlElementsLayout,$htmlElements);
+        }
 
         $parameters = [
             'moduleIds' => null,


### PR DESCRIPTION
Mit PHP8 kommt es zu folgender Fehlermeldung:

> request.CRITICAL: Uncaught PHP Exception TypeError: "array_merge(): Argument #1 must be of type array, null given" at /*/vendor/netzhirsch/cookie-opt-in-bundle/src/EventListener/PageLayoutListener.php line 256 {"exception":"[object] (TypeError(code: 0): array_merge(): Argument #1 must be of type array, null given at /*/vendor/netzhirsch/cookie-opt-in-bundle/src/EventListener/PageLayoutListener.php:256)"} []

 Hintergrund: array_merge prüft nun explizit ob es tatsächlich um Variablen des Typs Array handelt. Ist eine Variable NULL, dann wird nun ein Fataler Fehler ausgeworfen.