### PR TITLE
Übersetzungsfehler und PHP 8.1 Kompatibilitäts-Update

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -760,15 +760,15 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['position'] = [
 	'exclude'   => true,
 	'inputType' => 'select',
 	'options' => [
-		'leftTop' => $GLOBALS['TL_LANG']['tl_module']['leftTop'],
-		'leftCenter' => $GLOBALS['TL_LANG']['tl_module']['leftCenter'],
-		'leftBottom' => $GLOBALS['TL_LANG']['tl_module']['leftBottom'],
-		'centerTop' => $GLOBALS['TL_LANG']['tl_module']['centerTop'],
-		'centerCenter' => $GLOBALS['TL_LANG']['tl_module']['centerCenter'],
-		'centerBottom' => $GLOBALS['TL_LANG']['tl_module']['centerBottom'],
-		'rightTop' => $GLOBALS['TL_LANG']['tl_module']['rightTop'],
-		'rightCenter' => $GLOBALS['TL_LANG']['tl_module']['rightCenter'],
-		'rightBottom' => $GLOBALS['TL_LANG']['tl_module']['rightBottom'],
+		'leftTop' => &$GLOBALS['TL_LANG']['tl_module']['leftTop'],
+		'leftCenter' => &$GLOBALS['TL_LANG']['tl_module']['leftCenter'],
+		'leftBottom' => &$GLOBALS['TL_LANG']['tl_module']['leftBottom'],
+		'centerTop' => &$GLOBALS['TL_LANG']['tl_module']['centerTop'],
+		'centerCenter' => &$GLOBALS['TL_LANG']['tl_module']['centerCenter'],
+		'centerBottom' => &$GLOBALS['TL_LANG']['tl_module']['centerBottom'],
+		'rightTop' => &$GLOBALS['TL_LANG']['tl_module']['rightTop'],
+		'rightCenter' => &$GLOBALS['TL_LANG']['tl_module']['rightCenter'],
+		'rightBottom' => &$GLOBALS['TL_LANG']['tl_module']['rightBottom'],
 	],
 	'eval' => [
 		'tl_class'  =>  'w50',
@@ -816,10 +816,10 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['animation'] = [
 	'exclude'   => true,
 	'inputType' => 'select',
 	'options' => [
-		'go-up' => $GLOBALS['TL_LANG']['tl_module']['go-up'],
-		'shrink' => $GLOBALS['TL_LANG']['tl_module']['shrink'],
-        'shrink-and-rotate' => $GLOBALS['TL_LANG']['tl_module']['shrink-and-rotate'],
-        'hinge' => $GLOBALS['TL_LANG']['tl_module']['hinge'],
+		'go-up' => &$GLOBALS['TL_LANG']['tl_module']['go-up'],
+		'shrink' => &$GLOBALS['TL_LANG']['tl_module']['shrink'],
+        'shrink-and-rotate' => &$GLOBALS['TL_LANG']['tl_module']['shrink-and-rotate'],
+        'hinge' => &$GLOBALS['TL_LANG']['tl_module']['hinge'],
 	],
 	'eval' => [
 		'tl_class'  =>  'w50',
@@ -865,9 +865,9 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['ipFormatSave'] = [
     'exclude'   => true,
     'inputType' => 'select',
     'options' => [
-        'uncut' => $GLOBALS['TL_LANG']['tl_module']['uncut'],
-        'pseudo' => $GLOBALS['TL_LANG']['tl_module']['pseudo'],
-        'anon' => $GLOBALS['TL_LANG']['tl_module']['anon'],
+        'uncut' => &$GLOBALS['TL_LANG']['tl_module']['uncut'],
+        'pseudo' => &$GLOBALS['TL_LANG']['tl_module']['pseudo'],
+        'anon' => &$GLOBALS['TL_LANG']['tl_module']['anon'],
     ],
     'eval' => [
         'tl_class'  =>  'w50 ncoi---list--container',
@@ -890,6 +890,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['isNewCookieVersion'] = [
     'save_callback' => [['tl_module_ncoi', 'saveInNcoiTableCheckbox']],
     'load_callback' => [['tl_module_ncoi', 'loadFromNcoiTableCheckbox']],
 ];
+ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE);
 
 class tl_module_ncoi extends tl_module {
 
@@ -898,7 +899,7 @@ class tl_module_ncoi extends tl_module {
         $value = $this->loadFromNcoiTable($value,$dca);
 	    if (empty($value) || $value == 'a:2:{s:5:"value";s:0:"";s:4:"unit";s:2:"px";}')
 			$value = 'a:2:{s:5:"value";s:3:"500";s:4:"unit";s:2:"px";}';
-		
+
 		return $value;
 	}
 
@@ -982,7 +983,7 @@ class tl_module_ncoi extends tl_module {
                 $temp = $groups[0];
                 $groups[0] = [
                     'key' => '1',
-                    'value' => $GLOBALS['TL_LANG']['tl_module']['cookieToolGroupNames']['essential'],
+                    'value' => &$GLOBALS['TL_LANG']['tl_module']['cookieToolGroupNames']['essential'],
                 ];
                 if (!empty($temp)) {
                     $groups[array_key_last($groups)+1] = $temp;
@@ -1042,7 +1043,7 @@ class tl_module_ncoi extends tl_module {
 	public function getNetzhirschCookie($fieldValue,DC_Table $dca)
 	{
 		$id = $dca->id;
-		
+
 		$fieldPalettes = FieldPaletteModel::findByPid($id);
 		$csrfCookieFieldModel = null;
         $csrfHttpsCookieFieldModel = null;
@@ -1092,7 +1093,7 @@ class tl_module_ncoi extends tl_module {
                 $csrfCookieFieldModel->cookieToolsProvider = '';
                 $csrfCookieFieldModel->cookieToolExpiredTime = '0';
                 $csrfCookieFieldModel->cookieToolsSelect = '-';
-                $csrfCookieFieldModel->cookieToolsUse = $GLOBALS['TL_LANG']['tl_module']['contaoCsrfToken']['cookieToolsUse'];
+                $csrfCookieFieldModel->cookieToolsUse = &$GLOBALS['TL_LANG']['tl_module']['contaoCsrfToken']['cookieToolsUse'];
                 $csrfCookieFieldModel->cookieToolGroup = '1';
 
                 $csrfCookieFieldModel->save();
@@ -1125,7 +1126,7 @@ class tl_module_ncoi extends tl_module {
                 $csrfHttpsCookieFieldModel->cookieToolsProvider = '';
                 $csrfHttpsCookieFieldModel->cookieToolExpiredTime = '0';
                 $csrfHttpsCookieFieldModel->cookieToolsSelect = '-';
-                $csrfHttpsCookieFieldModel->cookieToolsUse = $GLOBALS['TL_LANG']['tl_module']['contaoCsrfHttpsToken']['cookieToolsUse'];
+                $csrfHttpsCookieFieldModel->cookieToolsUse = &$GLOBALS['TL_LANG']['tl_module']['contaoCsrfHttpsToken']['cookieToolsUse'];
                 $csrfHttpsCookieFieldModel->cookieToolGroup = '1';
 
                 $csrfHttpsCookieFieldModel->save();
@@ -1153,7 +1154,7 @@ class tl_module_ncoi extends tl_module {
                 $phpSessIdCookieFieldModel->cookieToolsProvider = '';
                 $phpSessIdCookieFieldModel->cookieToolExpiredTime = '0';
                 $phpSessIdCookieFieldModel->cookieToolsSelect = '-';
-                $phpSessIdCookieFieldModel->cookieToolsUse = $GLOBALS['TL_LANG']['tl_module']['phpSessionID']['cookieToolsUse'];
+                $phpSessIdCookieFieldModel->cookieToolsUse = &$GLOBALS['TL_LANG']['tl_module']['phpSessionID']['cookieToolsUse'];
                 $phpSessIdCookieFieldModel->cookieToolGroup = '1';
 
                 $phpSessIdCookieFieldModel->save();
@@ -1184,12 +1185,12 @@ class tl_module_ncoi extends tl_module {
                 $feUserAuthCookieFieldModel->cookieToolsProvider = '';
                 $feUserAuthCookieFieldModel->cookieToolExpiredTime = '0';
                 $feUserAuthCookieFieldModel->cookieToolsSelect = '-';
-                $feUserAuthCookieFieldModel->cookieToolsUse = $GLOBALS['TL_LANG']['tl_module']['FE_USER_AUTH']['cookieToolsUse'];
+                $feUserAuthCookieFieldModel->cookieToolsUse = &$GLOBALS['TL_LANG']['tl_module']['FE_USER_AUTH']['cookieToolsUse'];
                 $feUserAuthCookieFieldModel->cookieToolGroup = '1';
                 $feUserAuthCookieFieldModel->save();
             }
         }
-		
+
 		if (!empty($fieldValue)) {
 			$fieldValues = StringUtil::deserialize($fieldValue);
 			$fieldValues[] = [

--- a/src/Resources/contao/languages/de/tl_module.php
+++ b/src/Resources/contao/languages/de/tl_module.php
@@ -185,17 +185,17 @@ $GLOBALS['TL_LANG']['tl_module']['defaultCssDefault'] = true;
 
 $GLOBALS['TL_LANG']['tl_module']['position'] = ['Position'];
 
-$GLOBALS['TL_LANG']['tl_module']['leftTop'] = 'left top';
-$GLOBALS['TL_LANG']['tl_module']['leftCenter'] = 'left center';
-$GLOBALS['TL_LANG']['tl_module']['leftBottom'] = 'left bottom';
+$GLOBALS['TL_LANG']['tl_module']['leftTop'] = 'Links Oben';
+$GLOBALS['TL_LANG']['tl_module']['leftCenter'] = 'Links Mitte';
+$GLOBALS['TL_LANG']['tl_module']['leftBottom'] = 'Links Unten';
 
-$GLOBALS['TL_LANG']['tl_module']['centerTop'] = 'center top';
-$GLOBALS['TL_LANG']['tl_module']['centerCenter'] = 'center center';
-$GLOBALS['TL_LANG']['tl_module']['centerBottom'] = 'center bottom';
+$GLOBALS['TL_LANG']['tl_module']['centerTop'] = 'Mitte Oben';
+$GLOBALS['TL_LANG']['tl_module']['centerCenter'] = 'Mitte Mitte';
+$GLOBALS['TL_LANG']['tl_module']['centerBottom'] = 'Mitte Unten';
 
-$GLOBALS['TL_LANG']['tl_module']['rightTop'] = 'right top';
-$GLOBALS['TL_LANG']['tl_module']['rightCenter'] = 'right center';
-$GLOBALS['TL_LANG']['tl_module']['rightBottom'] = 'right bottom';
+$GLOBALS['TL_LANG']['tl_module']['rightTop'] = 'Rechts Oben';
+$GLOBALS['TL_LANG']['tl_module']['rightCenter'] = 'Rechts Mitte';
+$GLOBALS['TL_LANG']['tl_module']['rightBottom'] = 'Rechts Unten';
 
 $GLOBALS['TL_LANG']['tl_module']['cssTemplateStyle'] = ['Template Style'];
 

--- a/src/Resources/contao/modules/ModuleCookieOptInBar.php
+++ b/src/Resources/contao/modules/ModuleCookieOptInBar.php
@@ -29,7 +29,7 @@ class ModuleCookieOptInBar extends Module
      * @throws Less_Exception_Parser
      */
 	public function generate() {
-		
+
 		if (TL_MODE == 'BE') {
 			/** @var BackendTemplate|object $objTemplate */
 			$objTemplate = new BackendTemplate('be_wildcard');
@@ -42,8 +42,8 @@ class ModuleCookieOptInBar extends Module
 			return $objTemplate->parse();
 		}
 
-        $strQuery = "SELECT defaultCss,cssTemplateStyle,blockSite,zIndex,maxWidth,respectDoNotTrack 
-                FROM tl_ncoi_cookie 
+        $strQuery = "SELECT defaultCss,cssTemplateStyle,blockSite,zIndex,maxWidth,respectDoNotTrack
+                FROM tl_ncoi_cookie
                 WHERE pid = ?
         ";
 
@@ -193,7 +193,7 @@ class ModuleCookieOptInBar extends Module
 
         $data['privacyPolicy'] = self::getPrivacyPolicy($objPage,$result['privacyPolicy']);
 
-		$infoTitle = $result['infoTitle'];
+		$infoTitle = isset($result['infoTitle']) ? $result['infoTitle'] : '';
 		if (!empty($infoTitle)) {
 			$infoTitle = StringUtil::deserialize($infoTitle);
 			$data['infoTitle'] = "<".$infoTitle['unit'].">".$infoTitle['value']."</".$infoTitle['unit'].">";
@@ -205,7 +205,7 @@ class ModuleCookieOptInBar extends Module
 
 		$data['isExcludePage'] = false;
 		$currentPageId = $objPage->id;
-		$data['currentPage'] = $_SERVER['REDIRECT_URL'];
+		$data['currentPage'] = (isset($_SERVER['REDIRECT_URL']) ? $_SERVER['REDIRECT_URL'] : '');
 		$excludePages = StringUtil::deserialize($result['excludePages']);
         if (!empty($excludePages)) {
             foreach ($excludePages as $excludePage) {
@@ -235,7 +235,7 @@ class ModuleCookieOptInBar extends Module
 		$data['animation'] = '';
 		if (!empty($result['animation']))
 			$data['animation'] = $result['animation'];
-		
+
 		$data['position'] = $result['position'];
 
         $data['highlightSaveAllButton'] = $result['highlightSaveAllButton'];
@@ -266,7 +266,7 @@ class ModuleCookieOptInBar extends Module
 				Helper::parseLessToCss('netzhirschCookieOptIn.less','netzhirschCookieOptIn.css',$maxWidth,$blockSite,$zIndex);
 			}
 			$GLOBALS['TL_CSS'][] = 'bundles/netzhirschcookieoptin/netzhirschCookieOptIn.css|static';
-			
+
 			if ($cssTemplateStyle == 'dark'){
 				if (!file_exists($path.'netzhirschCookieOptInDarkVersion.css')) {
 					Helper::parseLessToCss('netzhirschCookieOptInDarkVersion.less','netzhirschCookieOptInDarkVersion.css');

--- a/src/Resources/contao/templates/mod_cookie_opt_in_bar.html5
+++ b/src/Resources/contao/templates/mod_cookie_opt_in_bar.html5
@@ -28,7 +28,7 @@
 			class="ncoi---container ncoi---mod-missing"
 			data-ncoi-cookie-version="<?php echo $this->arrData['cookieVersion']?>"
             data-is-exclude-page="<?=$this->arrData['isExcludePage']?>"
-			data-ncoi-mod-missing="<?php echo $this->arrData['moduleMissing']?>"
+			data-ncoi-mod-missing="<?=(isset($this->arrData['moduleMissing']) ? $this->arrData['moduleMissing'] : '' ) ?>"
 			data-ncoi-mod-id="<?php echo $this->arrData['id']?>"
             data-ncoi-animation="<?=$this->arrData['animation']?>"
             data-ncoi-respect-do-not-track="<?=$this->arrData['respectDoNotTrack']?>"

--- a/src/Resources/contao/templates/mod_cookie_opt_in_table.html5
+++ b/src/Resources/contao/templates/mod_cookie_opt_in_table.html5
@@ -80,6 +80,6 @@
             <?=(in_array($tool->cookieToolGroup, $this->arrData['cookieGroupsSelected']) && in_array($tool->id,$this->arrData['cookiesSelected']) || $tool->cookieToolGroup == '1') ? 'checked' : ''?>
             <?=($tool->cookieToolGroup == '1' ) ? 'disabled' : ''?>
         />
-        <label class="ncoi---sliding" for="ncoi---table-cookie-<?=$tool->id?>"><i></i><span><?=$cookieGroup?></span></label>
+        <label class="ncoi---sliding" for="ncoi---table-cookie-<?=$tool->id?>"><i></i><span><?=(isset($cookieGroup) ? $cookieGroup : '')?></span></label>
     </td>
 </tr>


### PR DESCRIPTION
Ein paar kleinere Bugfixes im Zusammenhang mit der Sprachdatei und der PHP 8.1 Unterstützung.

**Fix 1:** 
Ein paar Phrasen waren in der deutschen Sprachdatei noch auf englisch

**Fix 2:**
PHP 8 erzeugt bei fehlenden Array-Keys als Fehler-Typ nicht mehr "Notice", sondern "Warning". Dies führt bei aktiviertem Debug/Dev-Modus von Contao nun zu einem "harten" Fehler in Symfony. Als "Workaround" fügt dieser Patch eine Abfrage hinzu ob der Array-Key existiert und falls nein, wird ein leerer String zurückgeliefert. 

**Todo:** 
Im Zusammenhang mit dem Fix 2 wäre ggf. zu prüfen, warum die Array-Keys an dieser Stelle im Dev-/Debug-Modus nicht gesetzt sind und ob die aktuell leeren Strings zu noch unbekannten Problemen führen kann im Plugin.