### PR TITLE
PHP8.1 Warning-Fix: $cookieDatabase['otherScripts'] erzeugte eine Warnung

### DIFF
--- a/src/Controller/CookieController.php
+++ b/src/Controller/CookieController.php
@@ -88,9 +88,11 @@ class CookieController extends AbstractController
 				$cookiesToSet['cookieTools'][] = $cookieTool;
 		}
 
-		foreach ($cookieDatabase['otherScripts'] as $otherScripts) {
-			if (in_array($otherScripts['id'],$data['cookieIds']))
-				$cookiesToSet['otherScripts'][] = $otherScripts;
+		if($cookieDatabase['otherScripts'] !== NULL) {
+			foreach ($cookieDatabase['otherScripts'] as $otherScripts) {
+				if (in_array($otherScripts['id'],$data['cookieIds']))
+					$cookiesToSet['otherScripts'][] = $otherScripts;
+			}
 		}
 
         $this->deleteCookies(array_merge($cookiesToSet['cookieTools'],$cookiesToSet['otherScripts']));


### PR DESCRIPTION
Je nach Konfiguration kommt es vor, dass cookieDatabase['otherScripts'] = NULL. Das führt unter PHP 8.1 zu einer Warnung (und damit auch beim aktivierten DEBUG-Mode von Contao)