### PR TITLE
Fehlende Sprachdatei nachgeladen und Anpassung der Lizenzprüfung

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"php": ">=7.2",
 		"contao/core-bundle": ">=4.9 <5",
 		"heimrichhannot/contao-utils-bundle": ">2.195.1",
-		"heimrichhannot/contao-fieldpalette-bundle": "0.6.11",
+		"heimrichhannot/contao-fieldpalette-bundle": "^0.6",
 		"symfony/serializer": "*",
 		"ext-dom": "*",
 		"ext-json": "*",

--- a/src/EventListener/GetSystemMessagesListener.php
+++ b/src/EventListener/GetSystemMessagesListener.php
@@ -65,7 +65,7 @@ class GetSystemMessagesListener
 	 */
 	public static function getMessage($licenseKey,$licenseExpiryDate,$domain = null) {
 
-	    if (in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']))
+		if (filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE |  FILTER_FLAG_NO_RES_RANGE) === false)
             return '';
 
 		$kontaktString = $GLOBALS['TL_LANG']['BE_MOD']['netzhirsch']['cookieOptIn']['messages']['contact'];

--- a/src/EventListener/PageLayoutListener.php
+++ b/src/EventListener/PageLayoutListener.php
@@ -137,7 +137,7 @@ class PageLayoutListener {
         if (empty($licenseKey) || empty($licenseExpiryDate))
             return false;
 
-        if (in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']))
+        if (filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE |  FILTER_FLAG_NO_RES_RANGE) === false)
             return true;
 
         // in Frontend Y-m-d in Backend d.m.Y

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -13,6 +13,9 @@ if (TL_MODE == 'BE') {
     $GLOBALS['TL_CSS'][] = 'bundles/netzhirschcookieoptin/netzhirschCookieOptInBackend.css|static';
     $GLOBALS['TL_JAVASCRIPT']['jquery'] = 'bundles/netzhirschcookieoptin/jquery.min.js|static';
     $GLOBALS['TL_JAVASCRIPT']['ncoi'] = 'bundles/netzhirschcookieoptin/netzhirschCookieOptInBackend.js|static';
+
+    // Loading missing Language-File 'tl_layout'
+    \System::loadLanguageFile('tl_layout');  
 }
 
 $GLOBALS['TL_DCA']['tl_module']['palettes']['cookieOptInRevoke'] =


### PR DESCRIPTION
Liste der Bugfixes:

1. Neuere Version von _heimrichhannot/contao-fieldpalette-bundle_ in der composer.json hinterlegt, welches Bugfixes im Zusammenhang mit PHP 8 beinhaltet (Link: [Bugfix #17](https://github.com/heimrichhannot/contao-fieldpalette-bundle/commit/d9c863bcc81a12bbd2db6e4b2148c584bbbdc1ce)) 
2. Im Backend-Modul _Cookie Opt In Bar_ wird auf die Sprach-Datei 'tl_layout' zugegriffen, obwohl das Sprach-Datei nicht geladen ist (führt ebenfalls zu einer Warnung im Backend bei aktivierter Dev-Umgebung)

Nach diesem Patch sollte es im Zusammenhang mit CookieOptInBundle zu kleiner Warnung mehr unter PHP 8 / 8.1 oder 8.2 kommen. 

Verbesserungs-Vorschlag (optional):
1. Manche Entwickler/Unternehmen haben ihre Entwicklungsumgebung in einer virtuellen Umgebung, als Container oder einem dedizierten System im Büro laufen.  Daher wäre es von Vorteil REMOTE_ADDR nicht nur gegen localhost zu prüfen, sondern generell ob die IP Adresse in einer Private-IP Range liegt. 